### PR TITLE
Fixed bug with multiple desktops

### DIFF
--- a/Music Bar/Menu Bar/MenuBarManager.swift
+++ b/Music Bar/Menu Bar/MenuBarManager.swift
@@ -148,5 +148,6 @@ class MenuBarManager {
 		hiddenWindow = NSWindow(contentRect: NSMakeRect(0, 0, 15, height), styleMask: .borderless, backing: .buffered, defer: false)
 		hiddenWindow.backgroundColor = .red
 		hiddenWindow.alphaValue = 0
+		hiddenWindow.collectionBehavior = .canJoinAllSpaces
 	}
 }

--- a/docs/release-notes/1.3.3/index.html
+++ b/docs/release-notes/1.3.3/index.html
@@ -2,8 +2,17 @@
 <html>
 <body>
 	<ul>
-		<li><strong>macOS 10.14 (Mojave) support</strong> <br>
-			- Music Bar was previously only supported on Catalina. Mojave support has been added. Tell your friends! 😗
+		<li><strong>Added macOS 10.14 (Mojave) support</strong> <br>
+			Music Bar was previously only supported on Catalina. Mojave support has been added. Tell your friends! 😗 <br>
+			This was requested in <a href="https://github.com/musa11971/Music-Bar/issues/38">Issue #38</a>
+		</li>
+		<li><strong>Fixed a bug when using multiple desktops</strong> <br>
+			The popover would previously send you to the desktop that you opened Music Bar in. From now on, the popover will simply open in the desktop you are currently using. <br>
+			This bug was mentioned in:
+			<ul>
+				<li><a href="https://github.com/musa11971/Music-Bar/issues/30">Issue #30</a></li>
+				<li><a href="https://github.com/musa11971/Music-Bar/issues/39">Issue #39</a></li>
+			</ul>
 		</li>
 	</ul>
 


### PR DESCRIPTION
This PR fixes an annoying bug when using multiple desktops. When you press the menu bar button to open the popover, Music Bar would previously bring you to the desktop you opened the app in. From now on, the popover works on all desktop spaces.

Fixes #30 
Fixes #39 