### PR TITLE
Fixed the player's view when there's an 'empty' track playing

### DIFF
--- a/Music Bar/Music App/MusicApp.swift
+++ b/Music Bar/Music App/MusicApp.swift
@@ -40,9 +40,9 @@ class MusicApp {
 	var currentTrack: Track? {
 		didSet {
 			// Check if the new track is different than the previous one
-			if oldValue != currentTrack, let newTrack = currentTrack {
+			if oldValue != currentTrack {
 				// Update artwork when a new track is detected
-				updateArtwork(forTrack: newTrack)
+				updateArtwork(forTrack: currentTrack)
 			}
 			
 			// Post notification
@@ -117,6 +117,9 @@ class MusicApp {
                     // Set the current track
 					currentTrack = newTrack
                 }
+				else {
+					currentTrack = nil
+				}
             }
             
             // Update player position
@@ -132,9 +135,15 @@ class MusicApp {
     }
 	
 	// Retrieves the artwork of the current track from Apple
-	fileprivate func updateArtwork(forTrack track: Track) {
+	fileprivate func updateArtwork(forTrack track: Track?) {
 		// Post ArtworkWillChange notification
 		NotificationCenter.post(name: .ArtworkWillChange)
+		
+		if track == nil {
+			print("Artwork is empty")
+			self.artwork = PlayerViewController.defaultAlbumCover
+			return
+		}
 		
 		// Reset artwork color
 		self.artworkColor = nil
@@ -149,9 +158,10 @@ class MusicApp {
 		}
 		
 		// Start fetching artwork
-		artworkAPITask = URLSession.fetchJSON(fromURL: URL(string: "https://itunes.apple.com/search?term=\(track.searchTerm)&entity=song&limit=1")!) { (data, json, error) in
+		artworkAPITask = URLSession.fetchJSON(fromURL: URL(string: "https://itunes.apple.com/search?term=\(track!.searchTerm)&entity=song&limit=1")!) { (data, json, error) in
 			if error != nil {
 				print("Could not get artwork")
+				self.artwork = PlayerViewController.defaultAlbumCover
 				return
 			}
 

--- a/Music Bar/Player/PlayerViewController.swift
+++ b/Music Bar/Player/PlayerViewController.swift
@@ -122,9 +122,7 @@ class PlayerViewController: NSViewController {
 		// Add TrackDataDidChange observer
 		musicAppChangeObservers.append(
 			NotificationCenter.observe(name: .TrackDataDidChange) {
-				if let track = MusicApp.shared.currentTrack {
-					self.updateView(with: track)
-				}
+				self.updateView(with: MusicApp.shared.currentTrack)
 			}
 		)
 
@@ -172,9 +170,20 @@ class PlayerViewController: NSViewController {
 	}
 
 	// Updates the view according to the information in the given track.
-	func updateView(with track: Track) {
-		totalDurationTextField.stringValue = track.duration.durationString
-		playbackSlider.maxValue = Double(track.duration)
+	func updateView(with newTrack: Track?) {
+		if let track = newTrack {
+			totalDurationTextField.stringValue = track.duration.durationString
+			playbackSlider.maxValue = Double(track.duration)
+			
+			totalDurationTextField.isHidden = false
+			currentPlayerPositionTextField.isHidden = false
+			playbackSlider.isHidden = false
+		}
+		else {
+			totalDurationTextField.isHidden = true
+			currentPlayerPositionTextField.isHidden = true
+			playbackSlider.isHidden = true
+		}
 	}
 
 	// Updates the album image with a new image


### PR DESCRIPTION
When we don't retrieve any track properties from Apple Music, previously the app would show the album art from the previous track.
Now, a default album cover is show and the playback slider is hidden, since it cannot be used.

<img width="307" alt="Screenshot 2020-12-10 at 13 56 06" src="https://user-images.githubusercontent.com/21341801/101775798-4b9bdd00-3af0-11eb-934a-de19aa7c2671.png">
